### PR TITLE
Launcher3: Prevent LauncherPrefs crash during direct boot

### DIFF
--- a/src/com/android/launcher3/LauncherPrefs.kt
+++ b/src/com/android/launcher3/LauncherPrefs.kt
@@ -18,6 +18,7 @@ package com.android.launcher3
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import android.os.UserManager
 import androidx.annotation.VisibleForTesting
 import com.android.launcher3.GridType.Companion.GRID_TYPE_ANY
 import com.android.launcher3.InvariantDeviceProfile.GRID_NAME_PREFS_KEY
@@ -56,8 +57,20 @@ constructor(@ApplicationContext private val encryptedContext: Context) {
 
     open protected fun getSharedPrefs(item: Item): SharedPreferences =
         item.run {
-            if (encryptionType == EncryptionType.DEVICE_PROTECTED) deviceProtectedSharedPrefs
-            else encryptedContext.getSharedPreferences(sharedPrefFile, MODE_PRIVATE)
+            if (encryptionType == EncryptionType.DEVICE_PROTECTED) {
+                deviceProtectedSharedPrefs
+            } else {
+                val um = encryptedContext.getSystemService(UserManager::class.java)
+                val isUnlocked = um?.isUserUnlocked == true
+
+                val ctx = if (isUnlocked) {
+                    encryptedContext
+                } else {
+                    encryptedContext.createDeviceProtectedStorageContext()
+                }
+
+                ctx.getSharedPreferences(sharedPrefFile, MODE_PRIVATE)
+            }
         }
 
     @Deprecated("Don't use shared preferences directly. Use other LauncherPref methods.")


### PR DESCRIPTION
* Fall back to device-protected prefs when used is locked.

Log:

01-26 10:24:00.611  2951  2951 E AndroidRuntime: FATAL EXCEPTION: main
01-26 10:24:00.611  2951  2951 E AndroidRuntime: Process: com.android.launcher3, PID: 2951
01-26 10:24:00.611  2951  2951 E AndroidRuntime: java.lang.RuntimeException: Unable to create service com.android.quickstep.TouchInteractionService
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.app.ActivityThread.handleCreateService(ActivityThread.java:5564)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.app.ActivityThread.-$$Nest$mhandleCreateService(Unknown Source:0)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2734)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:132)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.os.Looper.dispatchMessage(Looper.java:333)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:263)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:367)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:9298)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:569)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: Caused by: java.lang.IllegalStateException: SharedPreferences in credential encrypted storage are not available until after user (id 0) is unlocked
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.app.ContextImpl.getSharedPreferences(ContextImpl.java:658)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.app.ContextImpl.getSharedPreferences(ContextImpl.java:636)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.content.ContextWrapper.getSharedPreferences(ContextWrapper.java:223)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.LauncherPrefs.getSharedPrefs(LauncherPrefs.kt:60)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.LauncherPrefs.getInner(LauncherPrefs.kt:85)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.LauncherPrefs.get(LauncherPrefs.kt:76)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.ConstantItem.get(LauncherPrefs.kt:430)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.InvariantDeviceProfile$DisplayOption.<init>(InvariantDeviceProfile.java:1476)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.InvariantDeviceProfile.getPredefinedDeviceProfiles(InvariantDeviceProfile.java:607)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.InvariantDeviceProfile.initGrid(InvariantDeviceProfile.java:348)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.InvariantDeviceProfile.<init>(InvariantDeviceProfile.java:301)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.InvariantDeviceProfile_Factory.newInstance(InvariantDeviceProfile_Factory.java:100)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.InvariantDeviceProfile_Factory.get(InvariantDeviceProfile_Factory.java:72)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.InvariantDeviceProfile_Factory.get(InvariantDeviceProfile_Factory.java:18)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at dagger.internal.DoubleCheck.getSynchronized(DoubleCheck.java:54)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at dagger.internal.DoubleCheck.get(DoubleCheck.java:45)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.taskbar.DaggerTaskbarBootComponent$TaskbarBootComponentImpl.getIDP(DaggerTaskbarBootComponent.java:1283)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.InvariantDeviceProfile$$ExternalSyntheticLambda0.apply(R8$$SyntheticClass:0)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.util.DaggerSingletonObject.get(DaggerSingletonObject.java:41)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.LauncherAppState$Companion.getIDP(LauncherAppState.kt:61)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.LauncherAppState.getIDP(LauncherAppState.kt:0)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.taskbar.TaskbarManagerImpl.getDeviceProfile(TaskbarManagerImpl.java:1552)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.taskbar.TaskbarManagerImpl.recreateTaskbarForDisplay(TaskbarManagerImpl.java:874)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.launcher3.taskbar.TaskbarManagerImpl.<init>(TaskbarManagerImpl.java:563)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at com.android.quickstep.TouchInteractionService.onCreate(TouchInteractionService.java:792)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	at android.app.ActivityThread.handleCreateService(ActivityThread.java:5553)
01-26 10:24:00.611  2951  2951 E AndroidRuntime: 	... 10 more